### PR TITLE
VS Code Tasks and a basic node + launch file

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,10 +5,15 @@ FROM ros:galactic
 RUN apt-get update && apt-get install -y \
   # To use git in the container
   git \
+  # pip is a package manager for Python
+  python3-pip \
   # To let us sync with GitHub over SSH
   ssh-client \
   # Clean out the apt lists after `apt-get update`
   && rm -rf /var/lib/apt/lists/*
+
+# Update pydocstyle to remove a deprecation warning when testing for PEP257
+RUN pip install --upgrade pydocstyle
 
 # Add a user so we can remote into this container with a non-root user
 RUN useradd trickfire \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,11 +10,13 @@
         "--security-opt", "seccomp=unconfined"
     ],
     "extensions": [
-        "ms-azuretools.vscode-docker",
+		"ms-azuretools.vscode-docker",
+		"ms-iot.vscode-ros",
 		"ms-python.python",
+		"ms-python.vscode-pylance",
 		"ms-vscode.cmake-tools",
 		"ms-vscode.cpptools",
 		"twxs.cmake",
-        "yzhang.markdown-all-in-one"
+		"yzhang.markdown-all-in-one"
 	]
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,12 +11,12 @@
     ],
     "extensions": [
 		"ms-azuretools.vscode-docker",
-		"ms-iot.vscode-ros",
 		"ms-python.python",
 		"ms-python.vscode-pylance",
 		"ms-vscode.cmake-tools",
 		"ms-vscode.cpptools",
 		"twxs.cmake",
-		"yzhang.markdown-all-in-one"
+		"yzhang.markdown-all-in-one",
+        "ms-iot.vscode-ros"
 	]
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,6 @@
 		"ms-vscode.cmake-tools",
 		"ms-vscode.cpptools",
 		"twxs.cmake",
-		"yzhang.markdown-all-in-one",
-        "ms-iot.vscode-ros"
+		"yzhang.markdown-all-in-one"
 	]
 }

--- a/.devcontainer/trickfire.bashrc
+++ b/.devcontainer/trickfire.bashrc
@@ -115,3 +115,5 @@ if ! shopt -oq posix; then
     . /etc/bash_completion
   fi
 fi
+
+source /opt/ros/"${ROS_DISTRO}"/setup.bash

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 /build/
 /install/
 /log/
+
+# Python scripts compiled as bytecode.
+__pycache__/

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,17 @@
+{
+    "configurations": [
+        {
+            "name": "Linux",
+            "includePath": [
+                "${workspaceFolder}/**",
+                "/opt/ros/galactic/include/**"
+            ],
+            "defines": [],
+            "compilerPath": "/usr/bin/gcc",
+            "cStandard": "gnu17",
+            "cppStandard": "gnu++14",
+            "intelliSenseMode": "linux-gcc-x64"
+        }
+    ],
+    "version": 4
+}

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -8,8 +8,8 @@
             ],
             "defines": [],
             "compilerPath": "/usr/bin/gcc",
-            "cStandard": "gnu17",
-            "cppStandard": "gnu++14",
+            "cStandard": "c99",
+            "cppStandard": "c++17",
             "intelliSenseMode": "linux-gcc-x64"
         }
     ],

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,7 @@
     "python.analysis.extraPaths": [
         "/opt/ros/galactic/lib/python3.8/site-packages"
     ],
-    "cmake.configureOnOpen": false
+    "cmake.configureOnOpen": false,
+    "python.linting.enabled": true,
+    "python.linting.flake8Enabled": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "python.autoComplete.extraPaths": [
+        "/opt/ros/galactic/lib/python3.8/site-packages"
+    ],
+    "python.analysis.extraPaths": [
+        "/opt/ros/galactic/lib/python3.8/site-packages"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,6 @@
     ],
     "python.analysis.extraPaths": [
         "/opt/ros/galactic/lib/python3.8/site-packages"
-    ]
+    ],
+    "cmake.configureOnOpen": false
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -35,6 +35,12 @@
 				"isDefault": true
 			},
 			"label": "test"
-		}
+		},
+		{
+			"type": "shell",
+            "command": "rm -rf ${workspaceFolder}/build ${workspaceFolder}/install ${workspaceFolder}/log",
+			"problemMatcher": [],
+			"label": "purge"
+        },
 	]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,29 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			// colcon is a build tool that handles multi-package workspaces with nested dependencies.
+			"type": "colcon",
+			"args": [
+				"build",
+				// Where possible, create symlinks instead of copying files.
+				"--symlink-install",
+				"--base-paths",
+				"/home/trickfire/NasaRmc2022",
+				"--cmake-args",
+				// Debug builds are less optimized but build faster than Release or RelWithDebInfo builds.
+				// Debug and RelWithDebInfo builds add symbol info to the executables/libraries so
+				// debuggers can show you function names, line numbers, etc.
+				"-DCMAKE_BUILD_TYPE=Debug"
+			],
+			"problemMatcher": [
+				"$catkin-gcc"
+			],
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			},
+			"label": "colcon: build"
+		}
+	]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -9,23 +9,11 @@
 			"group": { "kind": "build", "isDefault": true }
 		},
 		{
-			"label": "launch",
-			"type": "shell",
-			"command": "./launch.sh",
-			"problemMatcher": []
-		},
-		{
 			"label": "test",
 			"type": "shell",
 			"command": "./test.sh",
 			"problemMatcher": [],
 			"group": { "kind": "test", "isDefault": true }
-		},
-		{
-			"label": "purge",
-			"type": "shell",
-            "command": "rm -rf build install log",
-			"problemMatcher": []
-        },
+		}
 	]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -3,18 +3,9 @@
 	"tasks": [
 		{
 			"label": "build",
-			"type": "colcon",
-			"args": [
-				"build",
-				"--symlink-install",
-				"--base-paths",
-				"/home/trickfire/NasaRmc2022",
-				"--cmake-args",
-				"-DCMAKE_BUILD_TYPE=Debug"
-			],
-			"problemMatcher": [
-				"$catkin-gcc"
-			],
+			"type": "shell",
+			"command": "${workspaceFolder}/build.sh",
+			"problemMatcher": [],
 			"group": {
 				"kind": "build",
 				"isDefault": true
@@ -22,34 +13,13 @@
 		},
 		{
 			"label": "test",
-			"dependsOn": ["pre-test"],
-			"type": "colcon",
-			"args": [
-				"test-result",
-				"--test-result-base",
-				"/home/trickfire/NasaRmc2022",
-				"--verbose"
-			],
-			"problemMatcher": [
-				"$catkin-gcc"
-			],
+			"type": "shell",
+			"command": "${workspaceFolder}/test.sh",
+			"problemMatcher": [],
 			"group": {
 				"kind": "test",
 				"isDefault": true
 			}
-		},
-		{
-			"label": "pre-test",
-			"type": "colcon",
-			"args": [
-				"test",
-				"--base-paths",
-				"/home/trickfire/NasaRmc2022"
-			],
-			"problemMatcher": [
-				"$catkin-gcc"
-			],
-			"group": "test"
 		},
 		{
 			"label": "purge",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,6 +2,7 @@
 	"version": "2.0.0",
 	"tasks": [
 		{
+			"label": "build",
 			"type": "colcon",
 			"args": [
 				"build",
@@ -17,10 +18,28 @@
 			"group": {
 				"kind": "build",
 				"isDefault": true
-			},
-			"label": "build"
+			}
 		},
 		{
+			"label": "test",
+			"dependsOn": ["pre-test"],
+			"type": "colcon",
+			"args": [
+				"test-result",
+				"--test-result-base",
+				"/home/trickfire/NasaRmc2022",
+				"--verbose"
+			],
+			"problemMatcher": [
+				"$catkin-gcc"
+			],
+			"group": {
+				"kind": "test",
+				"isDefault": true
+			}
+		},
+		{
+			"label": "pre-test",
 			"type": "colcon",
 			"args": [
 				"test",
@@ -30,17 +49,13 @@
 			"problemMatcher": [
 				"$catkin-gcc"
 			],
-			"group": {
-				"kind": "test",
-				"isDefault": true
-			},
-			"label": "test"
+			"group": "test"
 		},
 		{
+			"label": "purge",
 			"type": "shell",
             "command": "rm -rf ${workspaceFolder}/build ${workspaceFolder}/install ${workspaceFolder}/log",
-			"problemMatcher": [],
-			"label": "purge"
+			"problemMatcher": []
         },
 	]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,27 +4,27 @@
 		{
 			"label": "build",
 			"type": "shell",
-			"command": "${workspaceFolder}/build.sh",
-			"problemMatcher": [],
-			"group": {
-				"kind": "build",
-				"isDefault": true
-			}
+			"command": "./build.sh",
+			"problemMatcher": ["$gcc"],
+			"group": { "kind": "build", "isDefault": true }
+		},
+		{
+			"label": "launch",
+			"type": "shell",
+			"command": "./launch.sh",
+			"problemMatcher": []
 		},
 		{
 			"label": "test",
 			"type": "shell",
-			"command": "${workspaceFolder}/test.sh",
+			"command": "./test.sh",
 			"problemMatcher": [],
-			"group": {
-				"kind": "test",
-				"isDefault": true
-			}
+			"group": { "kind": "test", "isDefault": true }
 		},
 		{
 			"label": "purge",
 			"type": "shell",
-            "command": "rm -rf ${workspaceFolder}/build ${workspaceFolder}/install ${workspaceFolder}/log",
+            "command": "rm -rf build install log",
 			"problemMatcher": []
         },
 	]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,18 +2,13 @@
 	"version": "2.0.0",
 	"tasks": [
 		{
-			// colcon is a build tool that handles multi-package workspaces with nested dependencies.
 			"type": "colcon",
 			"args": [
 				"build",
-				// Where possible, create symlinks instead of copying files.
 				"--symlink-install",
 				"--base-paths",
 				"/home/trickfire/NasaRmc2022",
 				"--cmake-args",
-				// Debug builds are less optimized but build faster than Release or RelWithDebInfo builds.
-				// Debug and RelWithDebInfo builds add symbol info to the executables/libraries so
-				// debuggers can show you function names, line numbers, etc.
 				"-DCMAKE_BUILD_TYPE=Debug"
 			],
 			"problemMatcher": [
@@ -23,7 +18,23 @@
 				"kind": "build",
 				"isDefault": true
 			},
-			"label": "colcon: build"
+			"label": "build"
+		},
+		{
+			"type": "colcon",
+			"args": [
+				"test",
+				"--base-paths",
+				"/home/trickfire/NasaRmc2022"
+			],
+			"problemMatcher": [
+				"$catkin-gcc"
+			],
+			"group": {
+				"kind": "test",
+				"isDefault": true
+			},
+			"label": "test"
 		}
 	]
 }

--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ Get started on [Windows](docs/install_on_windows.md) | [Linux](docs/install_on_l
 
 ## Quick Reference (VS Code)
 Build all packages: `Ctrl+Shift+B`
-Test all packages: `Alt+Shift+T`
+Test all packages: `Ctrl+P` - type `task test` - `Enter`

--- a/README.md
+++ b/README.md
@@ -5,3 +5,7 @@ An overhaul of [Trickfire Robotics'](https://www.linkedin.com/company/trickfire-
 We develop using [Docker](https://en.wikipedia.org/wiki/Docker_(software)) and [Visual Studio Code](https://code.visualstudio.com/). Docker containers keep the development environment well-defined and repeatable: no more mysterious missing dependencies. VS Code is a customizable text editor that has extensions for Docker and all of our programming languages.
 
 Get started on [Windows](docs/install_on_windows.md) | [Linux](docs/install_on_linux.md) | [Mac](docs/install_on_mac.md)
+
+## Quick Reference (VS Code)
+Build all packages: `Ctrl+Shift+B`
+Test all packages: `Alt+Shift+T`

--- a/README.md
+++ b/README.md
@@ -7,7 +7,12 @@ We develop using [Docker](https://en.wikipedia.org/wiki/Docker_(software)) and [
 Get started on [Windows](docs/install_on_windows.md) | [Linux](docs/install_on_linux.md) | [Mac](docs/install_on_mac.md)
 
 ## Quick Reference (VS Code)
-| Action             | Command                                   |
-| ------------------ | ----------------------------------------- |
-| Build all packages | `Ctrl+Shift+B`                            |
-| Test all packages  | `Ctrl+P`, type `task test`, press `Enter` |
+Open/close the terminal in VS Code with `` Ctrl+` `` (backtick `` ` `` is on the same key as tilde `~`).
+
+| Action             | Terminal command | VS Code shortcut                          |
+| ------------------ | ---------------- | ----------------------------------------- |
+| Build all packages | `./build.sh`     | `Ctrl+Shift+B`                            |
+| Test all packages  | `./test.sh`      | `Ctrl+P`, type `task test`, press `Enter` |
+| Launch nodes       | `./launch.sh`    |                                           |
+
+Where available, use the VS Code shortcuts because they come with in-editor features such as problem matchers.

--- a/README.md
+++ b/README.md
@@ -7,5 +7,7 @@ We develop using [Docker](https://en.wikipedia.org/wiki/Docker_(software)) and [
 Get started on [Windows](docs/install_on_windows.md) | [Linux](docs/install_on_linux.md) | [Mac](docs/install_on_mac.md)
 
 ## Quick Reference (VS Code)
-Build all packages: `Ctrl+Shift+B`
-Test all packages: `Ctrl+P` - type `task test` - `Enter`
+| Action             | Command                                   |
+| ------------------ | ----------------------------------------- |
+| Build all packages | `Ctrl+Shift+B`                            |
+| Test all packages  | `Ctrl+P`, type `task test`, press `Enter` |

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+colcon build \
+    --symlink-install \
+    --base-paths /home/trickfire/NasaRmc2022 \
+    --cmake-args \
+        -DCMAKE_BUILD_TYPE=Debug

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+source /opt/ros/$ROS_DISTRO/setup.bash
+
 colcon build \
     --symlink-install \
     --base-paths /home/trickfire/NasaRmc2022 \

--- a/launch.sh
+++ b/launch.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+source /opt/ros/$ROS_DISTRO/setup.bash
+source /home/trickfire/NasaRmc2022/install/setup.bash
+
+ros2 launch houdini_launch robot.launch.py

--- a/src/hello_world/CMakeLists.txt
+++ b/src/hello_world/CMakeLists.txt
@@ -32,4 +32,17 @@ install(TARGETS
   RUNTIME DESTINATION bin
 )
 
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+
+  # the following line skips the linter which checks for copyrights
+  # uncomment the line when a copyright and license is not present in all source files
+  #set(ament_cmake_copyright_FOUND TRUE)
+  # the following line skips cpplint (only works in a git repo)
+  # uncomment the line when this package is not in a git repo
+  #set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
 ament_package()

--- a/src/hello_world/CMakeLists.txt
+++ b/src/hello_world/CMakeLists.txt
@@ -1,0 +1,35 @@
+cmake_minimum_required(VERSION 3.16)
+project(hello_world)
+
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rclcpp_components REQUIRED)
+
+add_library(hello_node_component SHARED
+  src/hello_node.cpp
+)
+
+ament_target_dependencies(hello_node_component
+  rclcpp
+  rclcpp_components
+)
+
+rclcpp_components_register_node(hello_node_component
+  PLUGIN "hello_world::hello_node"
+  EXECUTABLE hello_node
+)
+
+target_include_directories(hello_node_component
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
+
+install(TARGETS
+  hello_node_component
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+ament_package()

--- a/src/hello_world/include/hello_world/hello_node.hpp
+++ b/src/hello_world/include/hello_world/hello_node.hpp
@@ -8,7 +8,7 @@ namespace hello_world
 class hello_node : public rclcpp::Node
 {
 public:
-    hello_node(const rclcpp::NodeOptions& options);
+  hello_node(const rclcpp::NodeOptions & options);
 };
 
 } // namespace hello_world

--- a/src/hello_world/include/hello_world/hello_node.hpp
+++ b/src/hello_world/include/hello_world/hello_node.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "rclcpp/rclcpp.hpp"
+
+namespace hello_world
+{
+
+class hello_node : public rclcpp::Node
+{
+public:
+    hello_node(const rclcpp::NodeOptions& options);
+};
+
+} // namespace hello_world

--- a/src/hello_world/package.xml
+++ b/src/hello_world/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>hello_world</name>
+  <version>0.0.0</version>
+  <description>TODO: Package description</description>
+  <maintainer email="phillipov@outlook.com">trickfire</maintainer>
+  <license>TODO: License declaration</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/src/hello_world/package.xml
+++ b/src/hello_world/package.xml
@@ -12,6 +12,9 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
 
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/src/hello_world/src/hello_node.cpp
+++ b/src/hello_world/src/hello_node.cpp
@@ -3,10 +3,10 @@
 namespace hello_world
 {
 
-hello_node::hello_node(const rclcpp::NodeOptions& options)
+hello_node::hello_node(const rclcpp::NodeOptions & options)
 : Node("hello_node", options)
 {
-    RCLCPP_INFO(this->get_logger(), "Hello World!");
+  RCLCPP_INFO(this->get_logger(), "Hello World!");
 }
 
 } // namespace hello_world

--- a/src/hello_world/src/hello_node.cpp
+++ b/src/hello_world/src/hello_node.cpp
@@ -1,0 +1,15 @@
+#include "hello_world/hello_node.hpp"
+
+namespace hello_world
+{
+
+hello_node::hello_node(const rclcpp::NodeOptions& options)
+: Node("hello_node", options)
+{
+    RCLCPP_INFO(this->get_logger(), "Hello World!");
+}
+
+} // namespace hello_world
+
+#include "rclcpp_components/register_node_macro.hpp"
+RCLCPP_COMPONENTS_REGISTER_NODE(hello_world::hello_node)

--- a/src/houdini_launch/launch/robot.launch.py
+++ b/src/houdini_launch/launch/robot.launch.py
@@ -2,23 +2,29 @@ import launch
 from launch_ros.actions import ComposableNodeContainer
 from launch_ros.descriptions import ComposableNode
 
-def generate_launch_description():
-    robot_container = ComposableNodeContainer(
-        name='robot',
-        package='rclcpp_components',
-        namespace='',
-        executable='component_container',
-        composable_node_descriptions=[
-            ComposableNode(
-                package='hello_world',
-                plugin='hello_world::hello_node',
-                name='hello_node',
-            ),
-        ],
-        output='screen',
-        emulate_tty=True
-    )
+hello_node = ComposableNode(
+    package='hello_world',
+    plugin='hello_world::hello_node',
+    name='hello_node'
+)
 
+# Composable Nodes launched in a Composable Node container will share a process
+# and can use very fast inter-process communication instead of publishing
+# messages over a network socket.
+# Note: "Composable Node container" does not mean "Docker-like container".
+robot_container = ComposableNodeContainer(
+    name='robot',
+    package='rclcpp_components',
+    namespace='',
+    executable='component_container',
+    composable_node_descriptions=[
+        hello_node
+    ],
+    output='screen',
+    emulate_tty=True
+)
+
+def generate_launch_description():
     return launch.LaunchDescription([
         robot_container
     ])

--- a/src/houdini_launch/launch/robot.launch.py
+++ b/src/houdini_launch/launch/robot.launch.py
@@ -1,0 +1,24 @@
+import launch
+from launch_ros.actions import ComposableNodeContainer
+from launch_ros.descriptions import ComposableNode
+
+def generate_launch_description():
+    robot_container = ComposableNodeContainer(
+        name='robot',
+        package='rclcpp_components',
+        namespace='',
+        executable='component_container',
+        composable_node_descriptions=[
+            ComposableNode(
+                package='hello_world',
+                plugin='hello_world::hello_node',
+                name='hello_node',
+            ),
+        ],
+        output='screen',
+        emulate_tty=True
+    )
+
+    return launch.LaunchDescription([
+        robot_container
+    ])

--- a/src/houdini_launch/launch/robot.launch.py
+++ b/src/houdini_launch/launch/robot.launch.py
@@ -24,6 +24,7 @@ robot_container = ComposableNodeContainer(
     emulate_tty=True
 )
 
+
 def generate_launch_description():
     return launch.LaunchDescription([
         robot_container

--- a/src/houdini_launch/package.xml
+++ b/src/houdini_launch/package.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>houdini_launch</name>
+  <version>0.0.0</version>
+  <description>TODO: Package description</description>
+  <maintainer email="phillipov@outlook.com">trickfire</maintainer>
+  <license>TODO: License declaration</license>
+
+  <build_depend>hello_world</build_depend>
+
+  <exec_depend>hello_world</exec_depend>
+  <exec_depend>ros2launch</exec_depend>
+
+  <test_depend>ament_copyright</test_depend>
+  <test_depend>ament_flake8</test_depend>
+  <test_depend>ament_pep257</test_depend>
+  <test_depend>python3-pytest</test_depend>
+
+  <export>
+    <build_type>ament_python</build_type>
+  </export>
+</package>

--- a/src/houdini_launch/package.xml
+++ b/src/houdini_launch/package.xml
@@ -7,8 +7,6 @@
   <maintainer email="phillipov@outlook.com">trickfire</maintainer>
   <license>TODO: License declaration</license>
 
-  <build_depend>hello_world</build_depend>
-
   <exec_depend>hello_world</exec_depend>
   <exec_depend>ros2launch</exec_depend>
 

--- a/src/houdini_launch/setup.cfg
+++ b/src/houdini_launch/setup.cfg
@@ -1,0 +1,4 @@
+[develop]
+script_dir=$base/lib/houdini_launch
+[install]
+install_scripts=$base/lib/houdini_launch

--- a/src/houdini_launch/setup.cfg
+++ b/src/houdini_launch/setup.cfg
@@ -1,4 +1,0 @@
-[develop]
-script_dir=$base/lib/houdini_launch
-[install]
-install_scripts=$base/lib/houdini_launch

--- a/src/houdini_launch/setup.py
+++ b/src/houdini_launch/setup.py
@@ -1,4 +1,3 @@
-import os
 from setuptools import setup
 from glob import glob
 
@@ -7,7 +6,7 @@ package_name = 'houdini_launch'
 setup(
     name=package_name,
     version='0.0.0',
-    packages=[package_name],
+    packages=[],
     data_files=[
         # Register this package in the ament resource index.
         ('share/ament_index/resource_index/packages', ['resource/' + package_name]),
@@ -15,15 +14,11 @@ setup(
         ('share/' + package_name + '/launch', glob('launch/*.launch.py')),
     ],
     install_requires=['setuptools'],
-    # Zip-safety is not confirmed yet.
+    # Zip-safety is not yet confirmed.
     zip_safe=True,
     maintainer='trickfire',
     maintainer_email='phillipov@outlook.com',
     description='TODO: Package description',
     license='TODO: License declaration',
-    tests_require=['pytest'],
-    entry_points={
-        'console_scripts': [
-        ],
-    },
+    tests_require=['pytest']
 )

--- a/src/houdini_launch/setup.py
+++ b/src/houdini_launch/setup.py
@@ -1,0 +1,29 @@
+import os
+from setuptools import setup
+from glob import glob
+
+package_name = 'houdini_launch'
+
+setup(
+    name=package_name,
+    version='0.0.0',
+    packages=[package_name],
+    data_files=[
+        # Register this package in the ament resource index.
+        ('share/ament_index/resource_index/packages', ['resource/' + package_name]),
+        ('share/' + package_name, ['package.xml']),
+        ('share/' + package_name + '/launch', glob('launch/*.launch.py')),
+    ],
+    install_requires=['setuptools'],
+    # Zip-safety is not confirmed yet.
+    zip_safe=True,
+    maintainer='trickfire',
+    maintainer_email='phillipov@outlook.com',
+    description='TODO: Package description',
+    license='TODO: License declaration',
+    tests_require=['pytest'],
+    entry_points={
+        'console_scripts': [
+        ],
+    },
+)

--- a/src/houdini_launch/test/test_copyright.py
+++ b/src/houdini_launch/test/test_copyright.py
@@ -1,0 +1,23 @@
+# Copyright 2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_copyright.main import main
+import pytest
+
+
+@pytest.mark.copyright
+@pytest.mark.linter
+def test_copyright():
+    rc = main(argv=['.', 'test'])
+    assert rc == 0, 'Found errors'

--- a/src/houdini_launch/test/test_flake8.py
+++ b/src/houdini_launch/test/test_flake8.py
@@ -1,0 +1,25 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_flake8.main import main_with_errors
+import pytest
+
+
+@pytest.mark.flake8
+@pytest.mark.linter
+def test_flake8():
+    rc, errors = main_with_errors(argv=[])
+    assert rc == 0, \
+        'Found %d code style errors / warnings:\n' % len(errors) + \
+        '\n'.join(errors)

--- a/src/houdini_launch/test/test_pep257.py
+++ b/src/houdini_launch/test/test_pep257.py
@@ -1,0 +1,23 @@
+# Copyright 2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_pep257.main import main
+import pytest
+
+
+@pytest.mark.linter
+@pytest.mark.pep257
+def test_pep257():
+    rc = main(argv=['.', 'test'])
+    assert rc == 0, 'Found code style errors / warnings'

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+colcon test \
+    --base-paths /home/trickfire/NasaRmc2022
+
+colcon test-result \
+    --test-result-base /home/trickfire/NasaRmc2022 \
+    --verbose

--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+source /opt/ros/$ROS_DISTRO/setup.bash
+source /home/trickfire/NasaRmc2022/install/setup.bash
+
 colcon test \
     --base-paths /home/trickfire/NasaRmc2022
 


### PR DESCRIPTION
I made the `hello_world` package to show an example ROS2 Node and the `houdini_launch` package to contain our launch files, but it only launches `hello_world::hello_node` so far.

I also finished up the bare minimum VS Code Tasks that we need for the repo. The "test" task only runs linters right now, because we haven't written any of our own tests yet.

In a future PR, we can figure out how to integrate ROS2's many C++ linters with VS Code. Yes, they already run with the "test" task, but they don't get turned into Problems that highlight the exact offending line of code. In other words, it can be more tightly integrated with VS Code.

You'll notice that Python linting is integrated, though. I turned on the `flake8` linter to highlight the offending Python lines every time you save a script.